### PR TITLE
Allow overriding language string for removing an item

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Or include Choices directly:
     loadingText: 'Loading...',
     noResultsText: 'No results found',
     noChoicesText: 'No choices to choose from',
+    removeItemText: 'Remove item',
     itemSelectText: 'Press to select',
     addItemText: (value) => {
       return `Press Enter to add <b>"${value}"</b>`;

--- a/src/scripts/choices.ts
+++ b/src/scripts/choices.ts
@@ -981,7 +981,12 @@ class Choices {
 
     const addItemToFragment = (item: Item): void => {
       // Create new list element
-      const listItem = this._getTemplate('item', item, removeItemButton);
+      const listItem = this._getTemplate(
+        'item',
+        item,
+        removeItemButton,
+        this.config.removeItemText,
+      );
       // Append it to list
       fragment.appendChild(listItem);
     };

--- a/src/scripts/constants.ts
+++ b/src/scripts/constants.ts
@@ -69,6 +69,7 @@ export const DEFAULT_CONFIG: Options = {
   loadingText: 'Loading...',
   noResultsText: 'No results found',
   noChoicesText: 'No choices to choose from',
+  removeItemText: 'Remove item',
   itemSelectText: 'Press to select',
   uniqueItemText: 'Only unique values can be added',
   customAddItemText: 'Only values matching specific conditions can be added',

--- a/src/scripts/interfaces.ts
+++ b/src/scripts/interfaces.ts
@@ -632,6 +632,15 @@ export interface Options {
   noChoicesText: string | Types.stringFunction;
 
   /**
+   * The text that is used in the aria-label of the remove button.
+   *
+   * **Input types affected:** select-multiple
+   *
+   * @default 'Remove item'
+   */
+  removeItemText: string | Types.stringFunction;
+
+  /**
    * The text that is shown when a user hovers over a selectable choice.
    *
    * **Input types affected:** select-multiple, select-one

--- a/src/scripts/templates.ts
+++ b/src/scripts/templates.ts
@@ -94,6 +94,7 @@ const templates = {
       placeholder: isPlaceholder,
     }: Item,
     removeItemButton: boolean,
+    removeItemText: string,
   ): HTMLDivElement {
     const div = Object.assign(document.createElement('div'), {
       className: item,
@@ -126,17 +127,13 @@ const templates = {
         div.classList.remove(itemSelectable);
       }
       div.dataset.deletable = '';
-      /** @todo This MUST be localizable, not hardcoded! */
-      const REMOVE_ITEM_TEXT = 'Remove item';
+
       const removeButton = Object.assign(document.createElement('button'), {
         type: 'button',
         className: button,
-        innerHTML: REMOVE_ITEM_TEXT,
+        innerHTML: removeItemText,
       });
-      removeButton.setAttribute(
-        'aria-label',
-        `${REMOVE_ITEM_TEXT}: '${value}'`,
-      );
+      removeButton.setAttribute('aria-label', `${removeItemText}: '${value}'`);
       removeButton.dataset.button = '';
       div.appendChild(removeButton);
     }


### PR DESCRIPTION
## Description
Allows overriding the language string per the TODO in the code. Required for the multilingual setup we're using this for in @joomla

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (tooling change or documentation change)
- [x] Refactor (non-breaking change which maintains existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

I'm not 100% on whether this will be a breaking change for people overriding the item template (with the introduction of the new parameter). I think it will be fine but I don't have an implementation of that to hand to test with

## Checklist
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
