### PR TITLE
correct the fuse.js option in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Or include Choices directly:
     // Choices uses the great Fuse library for searching. You
     // can find more options here: https://github.com/krisk/Fuse#options
     fuseOptions: {
-      include: 'score'
+      includeScore: true
     },
     callbackOnInit: null,
     callbackOnCreateTemplates: null


### PR DESCRIPTION
The option that is given as example doesn't seem to be valid (according to https://fusejs.io/api/options.html).

