### PR TITLE
Fix/#832 space in classnames

### DIFF
--- a/src/scripts/components/container.test.ts
+++ b/src/scripts/components/container.test.ts
@@ -2,19 +2,29 @@ import { expect } from 'chai';
 import { stub } from 'sinon';
 import Container from './container';
 import { DEFAULT_CLASSNAMES } from '../constants';
+import { containsClassNames } from '../lib/utils';
 
 describe('components/container', () => {
   let instance;
   let element;
+  let classNames;
 
   beforeEach(() => {
     element = document.createElement('div');
     element.id = 'container';
+    classNames = {
+      ...DEFAULT_CLASSNAMES,
+      openState: `${DEFAULT_CLASSNAMES.openState} other`,
+      loadingState: `${DEFAULT_CLASSNAMES.loadingState} other`,
+      flippedState: `${DEFAULT_CLASSNAMES.flippedState} other`,
+      disabledState: `${DEFAULT_CLASSNAMES.disabledState} other`,
+      focusState: `${DEFAULT_CLASSNAMES.focusState} other`,
+    };
 
     document.body.appendChild(element);
     instance = new Container({
       element: document.getElementById('container') as HTMLElement,
-      classNames: DEFAULT_CLASSNAMES,
+      classNames,
       position: 'auto',
       type: 'text',
     });
@@ -24,6 +34,7 @@ describe('components/container', () => {
     document.body.innerHTML = '';
     element = null;
     instance = null;
+    classNames = null;
   });
 
   describe('constructor', () => {
@@ -32,7 +43,7 @@ describe('components/container', () => {
     });
 
     it('assigns classnames to class', () => {
-      expect(instance.classNames).to.eql(DEFAULT_CLASSNAMES);
+      expect(instance.classNames).to.eql(classNames);
     });
   });
 
@@ -163,7 +174,7 @@ describe('components/container', () => {
 
     it('adds open state class', () => {
       expect(
-        instance.element.classList.contains(DEFAULT_CLASSNAMES.openState),
+        containsClassNames(instance.element, classNames.openState),
       ).to.equal(true);
     });
 
@@ -190,7 +201,7 @@ describe('components/container', () => {
 
       it('adds adds flipped state class', () => {
         expect(
-          instance.element.classList.contains(DEFAULT_CLASSNAMES.flippedState),
+          containsClassNames(instance.element, classNames.flippedState),
         ).to.equal(true);
       });
 
@@ -207,7 +218,7 @@ describe('components/container', () => {
 
     it('adds open state class', () => {
       expect(
-        instance.element.classList.contains(DEFAULT_CLASSNAMES.openState),
+        containsClassNames(instance.element, classNames.openState),
       ).to.equal(false);
     });
 
@@ -227,7 +238,7 @@ describe('components/container', () => {
 
       it('removes adds flipped state class', () => {
         expect(
-          instance.element.classList.contains(DEFAULT_CLASSNAMES.flippedState),
+          containsClassNames(instance.element, classNames.flippedState),
         ).to.equal(false);
       });
 
@@ -272,11 +283,11 @@ describe('components/container', () => {
 
     it('adds focus state class', () => {
       expect(
-        instance.element.classList.contains(DEFAULT_CLASSNAMES.focusState),
+        containsClassNames(instance.element, classNames.focusState),
       ).to.equal(false);
       instance.addFocusState();
       expect(
-        instance.element.classList.contains(DEFAULT_CLASSNAMES.focusState),
+        containsClassNames(instance.element, classNames.focusState),
       ).to.equal(true);
     });
   });
@@ -288,11 +299,11 @@ describe('components/container', () => {
 
     it('removes focus state class', () => {
       expect(
-        instance.element.classList.contains(DEFAULT_CLASSNAMES.focusState),
+        containsClassNames(instance.element, classNames.focusState),
       ).to.equal(true);
       instance.removeFocusState();
       expect(
-        instance.element.classList.contains(DEFAULT_CLASSNAMES.focusState),
+        containsClassNames(instance.element, classNames.focusState),
       ).to.equal(false);
     });
   });
@@ -304,11 +315,11 @@ describe('components/container', () => {
 
     it('removes disabled state class', () => {
       expect(
-        instance.element.classList.contains(DEFAULT_CLASSNAMES.disabledState),
+        containsClassNames(instance.element, classNames.disabledState),
       ).to.equal(true);
       instance.enable();
       expect(
-        instance.element.classList.contains(DEFAULT_CLASSNAMES.disabledState),
+        containsClassNames(instance.element, classNames.disabledState),
       ).to.equal(false);
     });
 
@@ -342,11 +353,11 @@ describe('components/container', () => {
 
     it('removes disabled state class', () => {
       expect(
-        instance.element.classList.contains(DEFAULT_CLASSNAMES.disabledState),
+        containsClassNames(instance.element, classNames.disabledState),
       ).to.equal(false);
       instance.disable();
       expect(
-        instance.element.classList.contains(DEFAULT_CLASSNAMES.disabledState),
+        containsClassNames(instance.element, classNames.disabledState),
       ).to.equal(true);
     });
 
@@ -434,11 +445,11 @@ describe('components/container', () => {
 
     it('adds loading state class', () => {
       expect(
-        instance.element.classList.contains(DEFAULT_CLASSNAMES.loadingState),
+        containsClassNames(instance.element, classNames.loadingState),
       ).to.equal(false);
       instance.addLoadingState();
       expect(
-        instance.element.classList.contains(DEFAULT_CLASSNAMES.loadingState),
+        containsClassNames(instance.element, classNames.loadingState),
       ).to.equal(true);
     });
 
@@ -462,11 +473,11 @@ describe('components/container', () => {
 
     it('removes loading state class', () => {
       expect(
-        instance.element.classList.contains(DEFAULT_CLASSNAMES.loadingState),
+        containsClassNames(instance.element, classNames.loadingState),
       ).to.equal(true);
       instance.removeLoadingState();
       expect(
-        instance.element.classList.contains(DEFAULT_CLASSNAMES.loadingState),
+        containsClassNames(instance.element, classNames.loadingState),
       ).to.equal(false);
     });
 

--- a/src/scripts/components/container.ts
+++ b/src/scripts/components/container.ts
@@ -78,25 +78,25 @@ export default class Container {
   }
 
   open(dropdownPos: number): void {
-    this.element.classList.add(this.classNames.openState);
+    this.element.classList.add(...this.classNames.openState.split(' '));
     this.element.setAttribute('aria-expanded', 'true');
     this.isOpen = true;
 
     if (this.shouldFlip(dropdownPos)) {
-      this.element.classList.add(this.classNames.flippedState);
+      this.element.classList.add(...this.classNames.flippedState.split(' '));
       this.isFlipped = true;
     }
   }
 
   close(): void {
-    this.element.classList.remove(this.classNames.openState);
+    this.element.classList.remove(...this.classNames.openState.split(' '));
     this.element.setAttribute('aria-expanded', 'false');
     this.removeActiveDescendant();
     this.isOpen = false;
 
     // A dropdown flips if it does not have space within the page
     if (this.isFlipped) {
-      this.element.classList.remove(this.classNames.flippedState);
+      this.element.classList.remove(...this.classNames.flippedState.split(' '));
       this.isFlipped = false;
     }
   }
@@ -108,15 +108,15 @@ export default class Container {
   }
 
   addFocusState(): void {
-    this.element.classList.add(this.classNames.focusState);
+    this.element.classList.add(...this.classNames.focusState.split(' '));
   }
 
   removeFocusState(): void {
-    this.element.classList.remove(this.classNames.focusState);
+    this.element.classList.remove(...this.classNames.focusState.split(' '));
   }
 
   enable(): void {
-    this.element.classList.remove(this.classNames.disabledState);
+    this.element.classList.remove(...this.classNames.disabledState.split(' '));
     this.element.removeAttribute('aria-disabled');
     if (this.type === SELECT_ONE_TYPE) {
       this.element.setAttribute('tabindex', '0');
@@ -125,7 +125,7 @@ export default class Container {
   }
 
   disable(): void {
-    this.element.classList.add(this.classNames.disabledState);
+    this.element.classList.add(...this.classNames.disabledState.split(' '));
     this.element.setAttribute('aria-disabled', 'true');
     if (this.type === SELECT_ONE_TYPE) {
       this.element.setAttribute('tabindex', '-1');
@@ -147,13 +147,13 @@ export default class Container {
   }
 
   addLoadingState(): void {
-    this.element.classList.add(this.classNames.loadingState);
+    this.element.classList.add(...this.classNames.loadingState.split(' '));
     this.element.setAttribute('aria-busy', 'true');
     this.isLoading = true;
   }
 
   removeLoadingState(): void {
-    this.element.classList.remove(this.classNames.loadingState);
+    this.element.classList.remove(...this.classNames.loadingState.split(' '));
     this.element.removeAttribute('aria-busy');
     this.isLoading = false;
   }

--- a/src/scripts/components/dropdown.test.ts
+++ b/src/scripts/components/dropdown.test.ts
@@ -2,24 +2,31 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import Dropdown from './dropdown';
 import { DEFAULT_CLASSNAMES } from '../constants';
+import { containsClassNames } from '../lib/utils';
 
 describe('components/dropdown', () => {
   let instance;
   let choicesElement;
+  let classNames;
 
   beforeEach(() => {
     choicesElement = document.createElement('div');
     document.body.appendChild(choicesElement);
+    classNames = {
+      ...DEFAULT_CLASSNAMES,
+      activeState: `${DEFAULT_CLASSNAMES.activeState} other`,
+    };
     instance = new Dropdown({
       element: choicesElement,
       type: 'text',
-      classNames: DEFAULT_CLASSNAMES,
+      classNames,
     });
   });
 
   afterEach(() => {
     document.body.innerHTML = '';
     instance = null;
+    classNames = null;
   });
 
   describe('constructor', () => {
@@ -28,7 +35,7 @@ describe('components/dropdown', () => {
     });
 
     it('assigns classnames to instance', () => {
-      expect(instance.classNames).to.eql(DEFAULT_CLASSNAMES);
+      expect(instance.classNames).to.eql(classNames);
     });
   });
 
@@ -94,7 +101,7 @@ describe('components/dropdown', () => {
 
     it('adds active class', () => {
       expect(
-        instance.element.classList.contains(DEFAULT_CLASSNAMES.activeState),
+        containsClassNames(instance.element, classNames.activeState),
       ).to.equal(true);
     });
 
@@ -124,7 +131,7 @@ describe('components/dropdown', () => {
 
     it('adds active class', () => {
       expect(
-        instance.element.classList.contains(DEFAULT_CLASSNAMES.activeState),
+        containsClassNames(instance.element, classNames.activeState),
       ).to.equal(false);
     });
 

--- a/src/scripts/components/dropdown.ts
+++ b/src/scripts/components/dropdown.ts
@@ -36,7 +36,7 @@ export default class Dropdown {
    * Show dropdown to user by adding active state class
    */
   show(): this {
-    this.element.classList.add(this.classNames.activeState);
+    this.element.classList.add(...this.classNames.activeState.split(' '));
     this.element.setAttribute('aria-expanded', 'true');
     this.isActive = true;
 
@@ -47,7 +47,7 @@ export default class Dropdown {
    * Hide dropdown from user
    */
   hide(): this {
-    this.element.classList.remove(this.classNames.activeState);
+    this.element.classList.remove(...this.classNames.activeState.split(' '));
     this.element.setAttribute('aria-expanded', 'false');
     this.isActive = false;
 

--- a/src/scripts/components/wrapped-element.test.ts
+++ b/src/scripts/components/wrapped-element.test.ts
@@ -1,22 +1,29 @@
 import { expect } from 'chai';
 import WrappedElement from './wrapped-element';
 import { DEFAULT_CLASSNAMES } from '../constants';
+import { containsClassNames } from '../lib/utils';
 
 describe('components/wrappedElement', () => {
   let instance;
   let element;
+  let classNames;
 
   beforeEach(() => {
     element = document.createElement('select');
+    classNames = {
+      ...DEFAULT_CLASSNAMES,
+      input: `${DEFAULT_CLASSNAMES.input} other`,
+    };
     instance = new WrappedElement({
       element,
-      classNames: DEFAULT_CLASSNAMES,
+      classNames,
     });
   });
 
   afterEach(() => {
     document.body.innerHTML = '';
     instance = null;
+    classNames = null;
   });
 
   describe('constructor', () => {
@@ -25,7 +32,7 @@ describe('components/wrappedElement', () => {
     });
 
     it('assigns classnames to class', () => {
-      expect(instance.classNames).to.eql(DEFAULT_CLASSNAMES);
+      expect(instance.classNames).to.eql(classNames);
     });
 
     it('sets isDisabled flag to false', () => {
@@ -79,9 +86,9 @@ describe('components/wrappedElement', () => {
     it('hides element', () => {
       instance.conceal();
       expect(instance.element.tabIndex).to.equal(-1);
-      expect(
-        instance.element.classList.contains(instance.classNames.input),
-      ).to.equal(true);
+      expect(containsClassNames(instance.element, classNames.input)).to.equal(
+        true,
+      );
       expect(instance.element.hidden).to.be.true;
       expect(instance.element.getAttribute('data-choice')).to.equal('active');
       expect(instance.element.getAttribute('data-choice-orig-style')).to.equal(
@@ -101,9 +108,9 @@ describe('components/wrappedElement', () => {
     it('shows element', () => {
       instance.reveal();
       expect(instance.element.tabIndex).to.equal(0);
-      expect(
-        instance.element.classList.contains(instance.classNames.input),
-      ).to.equal(false);
+      expect(containsClassNames(instance.element, classNames.input)).to.equal(
+        false,
+      );
       expect(instance.element.hidden).to.be.false;
       expect(instance.element.getAttribute('style')).to.equal(originalStyling);
       expect(instance.element.getAttribute('aria-hidden')).to.equal(null);

--- a/src/scripts/components/wrapped-element.ts
+++ b/src/scripts/components/wrapped-element.ts
@@ -39,7 +39,7 @@ export default class WrappedElement {
 
   conceal(): void {
     // Hide passed input
-    this.element.classList.add(this.classNames.input);
+    this.element.classList.add(...this.classNames.input.split(' '));
     this.element.hidden = true;
 
     // Remove element from tab index
@@ -57,7 +57,7 @@ export default class WrappedElement {
 
   reveal(): void {
     // Reinstate passed element
-    this.element.classList.remove(this.classNames.input);
+    this.element.classList.remove(...this.classNames.input.split(' '));
     this.element.hidden = false;
     this.element.removeAttribute('tabindex');
 

--- a/src/scripts/lib/utils.test.ts
+++ b/src/scripts/lib/utils.test.ts
@@ -14,6 +14,7 @@ import {
   cloneObject,
   dispatchEvent,
   diff,
+  containsClassNames,
 } from './utils';
 
 describe('utils', () => {
@@ -253,6 +254,18 @@ describe('utils', () => {
       const output = diff(obj1, obj2);
 
       expect(output).to.deep.equal(['baz']);
+    });
+  });
+
+  describe('containsClassNames', () => {
+    it('determines if the element contains all the classNames', () => {
+      const classNames = 'first second';
+      const element = document.createElement('p');
+      element.classList.add('first');
+
+      expect(containsClassNames(element, classNames)).to.equal(false);
+      element.classList.add('second');
+      expect(containsClassNames(element, classNames)).to.equal(true);
     });
   });
 });

--- a/src/scripts/lib/utils.ts
+++ b/src/scripts/lib/utils.ts
@@ -178,3 +178,12 @@ export const diff = (
 
   return aKeys.filter(i => bKeys.indexOf(i) < 0);
 };
+
+export const containsClassNames = (
+  element: HTMLElement,
+  classNames: string,
+): boolean => {
+  return classNames
+    .split(' ')
+    .every(className => element.classList.contains(className));
+};

--- a/src/scripts/templates.ts
+++ b/src/scripts/templates.ts
@@ -116,14 +116,18 @@ const templates = {
     }
 
     if (isPlaceholder) {
-      div.classList.add(placeholder);
+      div.classList.add(...placeholder.split(' '));
     }
 
-    div.classList.add(highlighted ? highlightedState : itemSelectable);
+    div.classList.add(
+      ...(highlighted
+        ? highlightedState.split(' ')
+        : itemSelectable.split(' ')),
+    );
 
     if (removeItemButton) {
       if (disabled) {
-        div.classList.remove(itemSelectable);
+        div.classList.remove(...itemSelectable.split(' '));
       }
       div.dataset.deletable = '';
       /** @todo This MUST be localizable, not hardcoded! */
@@ -230,11 +234,11 @@ const templates = {
     });
 
     if (isSelected) {
-      div.classList.add(selectedState);
+      div.classList.add(...selectedState.split(' '));
     }
 
     if (isPlaceholder) {
-      div.classList.add(placeholder);
+      div.classList.add(...placeholder.split(' '));
     }
 
     div.setAttribute('role', groupId && groupId > 0 ? 'treeitem' : 'option');
@@ -247,11 +251,11 @@ const templates = {
     });
 
     if (isDisabled) {
-      div.classList.add(itemDisabled);
+      div.classList.add(...itemDisabled.split(' '));
       div.dataset.choiceDisabled = '';
       div.setAttribute('aria-disabled', 'true');
     } else {
-      div.classList.add(itemSelectable);
+      div.classList.add(...itemSelectable.split(' '));
       div.dataset.choiceSelectable = '';
     }
 
@@ -283,7 +287,7 @@ const templates = {
   }: Pick<ClassNames, 'list' | 'listDropdown'>): HTMLDivElement {
     const div = document.createElement('div');
 
-    div.classList.add(list, listDropdown);
+    div.classList.add(...list.split(' '), ...listDropdown.split(' '));
     div.setAttribute('aria-expanded', 'false');
 
     return div;


### PR DESCRIPTION
## Description
Fix for #832 

## This is the problem:
In some cases, we want to be able to pass multiple class names like so `'list first second'`. However, this is making an error because `classList.add` doesn't support space.

## Steps to reproduce:
When creating a Choices object, pass some custom classNames in the options. 
```javascript
new Choices(element, {
  itemSelectText: '',
  removeItemButton: true,
  classNames: {
    containerOuter: 'choices bg-gray-200 focus:bg-gray-100 focus:shadow shadow-inner appearance-none rounded w-full text-gray-700 leading-tight',
    containerInner: 'py-1 px-3',
    input: 'bg-gray-200 p-1',
  },
});
```

## This is my solution:
It is possible to pass multiple classNames like so ```element.classList.add('first', 'second')```

My solution is to let the user pass all the class names as a string with spaces. But internally it will generate an array and create an argument for each class name.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (tooling change or documentation change)
- [ ] Refactor (non-breaking change which maintains existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
