### PR TITLE
Enhance inputCloned text input with type and name

### DIFF
--- a/src/scripts/templates.test.ts
+++ b/src/scripts/templates.test.ts
@@ -494,7 +494,8 @@ describe('templates', () => {
       */
       const expectedOutput = strToEl(`
         <input
-          type="text"
+          type="search"
+          name="search_terms"
           class="${classes.input} ${classes.inputCloned}"
           autocomplete="off"
           role="textbox"

--- a/src/scripts/templates.ts
+++ b/src/scripts/templates.ts
@@ -267,7 +267,8 @@ const templates = {
     placeholderValue: string,
   ): HTMLInputElement {
     const inp = Object.assign(document.createElement('input'), {
-      type: 'text',
+      type: 'search',
+      name: 'search_terms',
       className: `${input} ${inputCloned}`,
       autocomplete: 'off',
       autocapitalize: 'off',


### PR DESCRIPTION
## This is the problem:
Safari will display a contact autocomplete on every text input which `name` attribute contains "*name*" or does not have any `name` attribute.
<img width="263" alt="Capture d’écran 2020-09-24 à 16 27 58" src="https://user-images.githubusercontent.com/907274/94158756-0ec23180-fe83-11ea-9de4-646ab5718e1c.png">

## Steps to reproduce:
Use defaut Choices.js (9.0.1) with macOS Safari 

## This is my solution:
Adding a fine tuned `name`attribute to the input should prevent that.

Plus, input type="search" seems more suited to the field intent (https://developer.mozilla.org/fr/docs/Web/HTML/Element/Input/search).

In the mean time, I'm using the same kind of solution explained in https://github.com/jshjohnson/Choices/issues/598#issuecomment-498506544, mimic-ing the attribute addition in this PR as a JS callback on page loaded:
```js
   const els = document.querySelectorAll('.choices__input--cloned');
    els.forEach((el, n) => {
      el.setAttribute("name", "search_terms")
      el.setAttribute("inputmode", "search")
    });
```


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (tooling change or documentation change)
- [x] Refactor (non-breaking change which maintains existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
