### PR TITLE
Adding ShadowDom support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,23 @@ Pass an array of objects:
 
 **Usage:** The maximum amount of search results to show.
 
+### shadowRoot
+
+**Type:** Document Element **Default:** null
+
+**Input types affected:** `select-one`, `select-multiple`
+
+**Usage:** You can pass along the shadowRoot from your application like so.
+
+```js
+var shadowRoot = document
+  .getElementById('wrapper')
+  .attachShadow({ mode: 'open' });
+var choices = new Choices({
+  shadowRoot: shadowRoot,
+});
+```
+
 ### position
 
 **Type:** `String` **Default:** `auto`

--- a/src/scripts/choices.ts
+++ b/src/scripts/choices.ts
@@ -128,6 +128,10 @@ class Choices {
       // instead of concatenating with the default array
       { arrayMerge: (_, sourceArray) => [...sourceArray] },
     );
+    // Restore the shadowRoot if provided. deeperge converts it into an empty object.
+    if (userConfig.shadowRoot) {
+      this.config.shadowRoot = userConfig.shadowRoot;
+    }
 
     const invalidConfigOptions = diff(this.config, DEFAULT_CONFIG);
     if (invalidConfigOptions.length) {
@@ -1308,7 +1312,7 @@ class Choices {
   }
 
   _addEventListeners(): void {
-    const { documentElement } = document;
+    const documentElement = this.config.shadowRoot || document.documentElement;
 
     // capture events - can cancel event processing or propagation
     documentElement.addEventListener('touchend', this._onTouchEnd, true);
@@ -1362,7 +1366,7 @@ class Choices {
   }
 
   _removeEventListeners(): void {
-    const { documentElement } = document;
+    const documentElement = this.config.shadowRoot || document.documentElement;
 
     documentElement.removeEventListener('touchend', this._onTouchEnd, true);
     this.containerOuter.element.removeEventListener(

--- a/src/scripts/constants.ts
+++ b/src/scripts/constants.ts
@@ -60,6 +60,7 @@ export const DEFAULT_CONFIG: Options = {
   shouldSort: true,
   shouldSortItems: false,
   sorter: sortByAlpha,
+  shadowRoot: null,
   placeholder: true,
   placeholderValue: null,
   searchPlaceholderValue: null,

--- a/src/scripts/interfaces.ts
+++ b/src/scripts/interfaces.ts
@@ -504,6 +504,11 @@ export interface Options {
   resetScrollPosition: boolean;
 
   /**
+   * The shadow root for use within ShadowDom
+   */
+  shadowRoot: any;
+
+  /**
    * Whether choices and groups should be sorted. If false, choices/groups will appear in the order they were given.
    *
    * **Input types affected:** select-one, select-multiple


### PR DESCRIPTION
## Description

This change allows for this library to work within a Shadow Dom
If you have this library embedded within a shadow dom, it will not work
Fixes:
 - https://github.com/jshjohnson/Choices/issues/819
 - https://github.com/jshjohnson/Choices/issues/805

## Screenshots (if appropriate)

## Types of changes

This adds a new configuration where you can pass the shadowRoot as a configuration. If you this configuration, then this will work in a shadow dom like so.

```js
var shadowRoot = document.getElementById('wrapper').attachShadow({ mode: 'open' });
var choices = new Choices({
  shadowRoot: shadowRoot
});
```

- [ ] Chore (tooling change or documentation change)
- [ ] Refactor (non-breaking change which maintains existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
