### PR TITLE
Fix - using / is deprecated - use math.div

### DIFF
--- a/src/styles/choices.scss
+++ b/src/styles/choices.scss
@@ -1,6 +1,7 @@
 /*===============================
 =            Choices            =
 ===============================*/
+@use "sass:math";
 
 $choices-selector: 'choices' !default;
 $choices-font-size-lg: 16px !default;
@@ -131,7 +132,7 @@ $choices-z-index: 1;
     position: relative;
     display: inline-block;
     margin-top: 0;
-    margin-right: -$choices-button-offset/2;
+    margin-right: math.div(-$choices-button-offset, 2);
     margin-bottom: 0;
     margin-left: $choices-button-offset;
     padding-left: $choices-button-offset * 2;


### PR DESCRIPTION
DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.

## Description

using math.div instead of "/"

## Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/2042388/124256193-51f4b380-db2b-11eb-9681-eb5088a8909c.png)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
