### PR TITLE
Fix broken demo link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 A vanilla, lightweight (~19kb gzipped 🎉), configurable select box/text input plugin. Similar to Select2 and Selectize but without the jQuery dependency.
 
-[Demo](https://joshuajohnson.co.uk/Choices/)
+[Demo](https://choices-js.github.io/Choices/)
 
 ## TL;DR
 


### PR DESCRIPTION
## Description

After trying to see the demo for this project I noticed that the link
leads to a 404 page.

I found the updated link in [#957] and this commit updates the README to
link to the proper URL.

[#957]: https://github.com/Choices-js/Choices/issues/957

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (tooling change or documentation change)
- [ ] Refactor (non-breaking change which maintains existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
