### PR TITLE
Solve deprecated warning using / for division outside of calc()

### DIFF
--- a/src/styles/base.scss
+++ b/src/styles/base.scss
@@ -65,7 +65,7 @@ h4,
 h5,
 h6 {
   margin-top: 0;
-  margin-bottom: $global-guttering * .5;
+  margin-bottom: $global-guttering * 0.5;
   font-weight: 400;
   line-height: 1.2;
 }
@@ -152,7 +152,7 @@ label + p {
 
 .logo {
   display: block;
-  margin-bottom: $global-guttering * .5;
+  margin-bottom: $global-guttering * 0.5;
 }
 
 .logo__img {
@@ -161,7 +161,7 @@ label + p {
   display: inline-block;
   max-width: 100%;
   vertical-align: top;
-  padding: $global-guttering * .25 0;
+  padding: $global-guttering * 0.25 0;
 }
 
 .visible-ie {

--- a/src/styles/base.scss
+++ b/src/styles/base.scss
@@ -65,7 +65,7 @@ h4,
 h5,
 h6 {
   margin-top: 0;
-  margin-bottom: $global-guttering/2;
+  margin-bottom: $global-guttering * .5;
   font-weight: 400;
   line-height: 1.2;
 }
@@ -152,7 +152,7 @@ label + p {
 
 .logo {
   display: block;
-  margin-bottom: $global-guttering/2;
+  margin-bottom: $global-guttering * .5;
 }
 
 .logo__img {
@@ -161,7 +161,7 @@ label + p {
   display: inline-block;
   max-width: 100%;
   vertical-align: top;
-  padding: $global-guttering/4 0;
+  padding: $global-guttering * .25 0;
 }
 
 .visible-ie {

--- a/src/styles/choices.scss
+++ b/src/styles/choices.scss
@@ -131,7 +131,7 @@ $choices-z-index: 1;
     position: relative;
     display: inline-block;
     margin-top: 0;
-    margin-right: -$choices-button-offset/2;
+    margin-right: -$choices-button-offset * .5;
     margin-bottom: 0;
     margin-left: $choices-button-offset;
     padding-left: $choices-button-offset * 2;

--- a/src/styles/choices.scss
+++ b/src/styles/choices.scss
@@ -131,7 +131,7 @@ $choices-z-index: 1;
     position: relative;
     display: inline-block;
     margin-top: 0;
-    margin-right: -$choices-button-offset * .5;
+    margin-right: -$choices-button-offset * 0.5;
     margin-bottom: 0;
     margin-left: $choices-button-offset;
     padding-left: $choices-button-offset * 2;


### PR DESCRIPTION
## Description

This PR will solve the Deprecated Warning created by Dart Sass 

## Screenshots (if appropriate)

```
Deprecation Warning: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div(-$choices-button-offset, 2) or calc(-$choices-button-offset / 2)

More info and automated migrator: https://sass-lang.com/d/slash-div

    ╷
129 │     margin-right: -$choices-button-offset/2;
    │                   ^^^^^^^^^^^^^^^^^^^^^^^^^
    ╵
    node_modules/choices.js/src/styles/choices.scss 129:19                @import

```

## Types of changes

To solve the deprecated warning using `/` for division outside of calc() you can use math.div instead. 
BUT... does math.div have a widespread support?
Dunno... on the other hand.... the multiplier `*` does have a widespread support.

SO instead of replacing `/` by math.div I propose to replace it by `*`
There are only five places in the code where the division is used and the numbers are simple

- replace `/2` by `* .5`
- replace `/4` by `* .25`

- [ ] Chore (tooling change or documentation change)
- [x] Refactor (non-breaking change which maintains existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

There is no need to change the documentation