### PR TITLE
Fix Sanitization of > Characters

### DIFF
--- a/src/scripts/components/input.test.ts
+++ b/src/scripts/components/input.test.ts
@@ -315,7 +315,7 @@ describe('components/input', () => {
       const value = '<script>somethingMalicious();</script>';
       instance.element.value = value;
       expect(instance.value).to.equal(
-        '&lt;script&rt;somethingMalicious();&lt;/script&rt;',
+        '&lt;script&gt;somethingMalicious();&lt;/script&gt;',
       );
     });
   });

--- a/src/scripts/lib/utils.test.ts
+++ b/src/scripts/lib/utils.test.ts
@@ -1,19 +1,20 @@
 /* eslint-disable no-new-wrappers */
 import { expect } from 'chai';
 import { stub } from 'sinon';
+
 import {
-  getRandomNumber,
+  cloneObject,
+  diff,
+  dispatchEvent,
+  existsInArray,
   generateChars,
   generateId,
+  getRandomNumber,
   getType,
   isType,
   sanitise,
   sortByAlpha,
   sortByScore,
-  existsInArray,
-  cloneObject,
-  dispatchEvent,
-  diff,
 } from './utils';
 
 describe('utils', () => {
@@ -113,7 +114,7 @@ describe('utils', () => {
         const value = '<script>somethingMalicious();</script>';
         const output = sanitise(value);
         expect(output).to.equal(
-          '&lt;script&rt;somethingMalicious();&lt;/script&rt;',
+          '&lt;script&gt;somethingMalicious();&lt;/script&gt;',
         );
       });
     });

--- a/src/scripts/lib/utils.ts
+++ b/src/scripts/lib/utils.ts
@@ -93,7 +93,7 @@ export const sanitise = <T>(value: T | string): T | string => {
 
   return value
     .replace(/&/g, '&amp;')
-    .replace(/>/g, '&rt;')
+    .replace(/>/g, '&gt;')
     .replace(/</g, '&lt;')
     .replace(/"/g, '&quot;');
 };


### PR DESCRIPTION
## Description

Correct sanitization of `>` character. Builds on #931.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (tooling change or documentation change)
- [ ] Refactor (non-breaking change which maintains existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
