### PR TITLE
Remove character sanitisation when searching

### DIFF
--- a/src/scripts/choices.test.ts
+++ b/src/scripts/choices.test.ts
@@ -1734,6 +1734,38 @@ describe('choices', () => {
     });
   });
 
+  describe('events', () => {
+    describe('search', () => {
+      beforeEach(() => {
+        document.body.innerHTML = `
+        <select data-choice multiple></select>
+        `;
+
+        instance = new Choices('[data-choice]', {
+          allowHTML: false,
+          searchEnabled: true,
+        });
+      });
+
+      it('details are passed', (done) => {
+        const query =
+          'This is a <search> query & a "test" with characters that should not be sanitised.';
+
+        instance.input.value = query;
+        instance.input.focus();
+        instance.passedElement.element.addEventListener('search', (event) => {
+          expect(event.detail).to.eql({
+            value: query,
+            resultCount: 0,
+          });
+          done();
+        });
+
+        instance._onKeyUp({ target: null, keyCode: null });
+      });
+    });
+  });
+
   describe('private methods', () => {
     describe('_createGroupsFragment', () => {
       let _createChoicesFragmentStub;

--- a/src/scripts/choices.ts
+++ b/src/scripts/choices.ts
@@ -1513,7 +1513,7 @@ class Choices implements Choices {
         this._isSearching = false;
         this._store.dispatch(activateChoices(true));
       } else if (canSearch) {
-        this._handleSearch(this.input.value);
+        this._handleSearch(this.input.rawValue);
       }
     }
 

--- a/src/scripts/components/input.ts
+++ b/src/scripts/components/input.ts
@@ -52,6 +52,10 @@ export default class Input {
     this.element.value = value;
   }
 
+  get rawValue(): string {
+    return this.element.value;
+  }
+
   addEventListeners(): void {
     this.element.addEventListener('paste', this._onPaste);
     this.element.addEventListener('input', this._onInput, {


### PR DESCRIPTION
## Description

Continuation of #879 

> Disabled character sanitization when searching as this was encoding characters (&,<,>"), which was resulting in options not being retrieved.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (tooling change or documentation change)
- [ ] Refactor (non-breaking change which maintains existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have added new tests for the bug I fixed/the new feature I added.
- [ ] I have modified existing tests for the bug I fixed/the new feature I added.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
