### PR TITLE
Fix multiple select in Internet Explorer 11

### DIFF
--- a/src/styles/choices.scss
+++ b/src/styles/choices.scss
@@ -40,7 +40,7 @@ $choices-z-index: 1;
   }
 
   &.is-open {
-    overflow: initial;
+    overflow: visible;
   }
 
   &.is-disabled {
@@ -191,6 +191,10 @@ $choices-z-index: 1;
   margin: 0;
   padding-left: 0;
   list-style: none;
+
+  &[aria-expanded] {
+    @extend .choices__list--dropdown;
+  }
 }
 
 .#{$choices-selector}__list--single {


### PR DESCRIPTION
Fix compatibility with Internet Explorer 11

## Description

See [Multiple select input doesn’t work on Internet Explorer 11 · Issue #887 · Choices-js/Choices](https://github.com/Choices-js/Choices/issues/887)

## Types of changes

- [ ] Chore (tooling change or documentation change)
- [ ] Refactor (non-breaking change which maintains existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the code style of this project.
- [ ] I have added new tests for the bug I fixed/the new feature I added.
- [ ] I have modified existing tests for the bug I fixed/the new feature I added.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
