### PR TITLE
README Fix: Use select-single everywhere, fix missing comma in default options

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Or include Choices directly:
     removeItems: true,
     removeItemButton: false,
     editItems: false,
-    allowHTML: true
+    allowHTML: true,
     duplicateItemsAllowed: true,
     delimiter: ',',
     paste: true,
@@ -206,7 +206,7 @@ Choices works with the following input types, referenced in the documentation as
 | HTML Element                                                                                           | Documentation "Input Type" |
 | -------------------------------------------------------------------------------------------------------| -------------------------- |
 | [`<input type="text">`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input)               | `text`                     |
-| [`<select>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select)                         | `select-single`            |
+| [`<select>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select)                         | `select-one`               |
 | [`<select multiple>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select#attr-multiple)  | `select-multiple`          |
 
 ## Configuration Options
@@ -215,7 +215,7 @@ Choices works with the following input types, referenced in the documentation as
 
 **Type:** `Boolean` **Default:** `false`
 
-**Input types affected:** `text`, `select-single`, `select-multiple`
+**Input types affected:** `text`, `select-one`, `select-multiple`
 
 **Usage:** Optionally suppress console errors and warnings.
 


### PR DESCRIPTION
## Description

- use  `select-one` consistently (instead of `select-single` with two occurrences)
- add missing comma (,) in setup example with default options

## Screenshots

Also update repo tags?

![image](https://user-images.githubusercontent.com/23225429/149637609-24735144-548f-4646-a606-19d9f159222d.png)

## Types of changes

- [x] Chore (tooling change or documentation change)
- [ ] Refactor (non-breaking change which maintains existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- not really needed
