### PR TITLE
Fix custom properties for browsers

### DIFF
--- a/public/assets/scripts/choices.js
+++ b/public/assets/scripts/choices.js
@@ -399,7 +399,7 @@ function () {
           selected: !!option.selected,
           disabled: option.disabled || option.parentNode.disabled,
           placeholder: option.value === '' || option.hasAttribute('placeholder'),
-          customProperties: option.dataset['custom-properties']
+          customProperties: option.dataset['customProperties']
         });
       });
     }


### PR DESCRIPTION
Custom properties does not work correct for Chrome and Firefox Browsers. It returns 'undefined' and [object Object] from client side.

To reproduce it just add 'data-custom-properties' to your option and check it in Chrome or Firefox like that:
`<option value="1" data-custom-properties='<span>Primary</span>'>1</option>`

This small change fixes custom properties fields for browsers. Without it only Safari supports custom properties.

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ x  ] My code follows the code style of this project.
