### PR TITLE
Fix regression where webpack doesn't permit importing scss/css

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     ".": {
       "types": "./public/types/src/index.d.ts",
       "import": "./public/assets/scripts/choices.mjs",
-      "require": "./public/assets/scripts/choices.js"
+      "require": "./public/assets/scripts/choices.js",
+      "style": "./public/assets/styles/choices.css",
+      "sass": "./src/styles/choices.scss"
     },
     "./search-basic": {
       "types": "./public/types/src/index.d.ts",
@@ -23,9 +25,15 @@
       "types": "./public/types/src/index.d.ts",
       "import": "./public/assets/scripts/choices.search-none.mjs",
       "require": "./public/assets/scripts/choices.search-none.min.js"
-    }
+    },
+    "./public/assets/styles/*.css": "./public/assets/styles/*.css",
+    "./src/styles/*.scss": "./src/styles/*.scss",
+    "./src/styles/*": "./src/styles/*.scss"
   },
-  "sideEffects": false,
+  "sideEffects": [
+    "*.scss",
+    "*.css"
+  ],
   "scripts": {
     "start": "run-p js:watch css:watch",
     "build": "run-p js:build css:build",


### PR DESCRIPTION
Add some entries to `package.json` to improve compatibility with webpack

- Add default `style` and `sass` exports as per webpack requirements
- Add `public/assets/styles/*` exports for CSS files
- Add `src/styles/*` exports for Scss files. Extension can be omitted to prevent linting issues with `stylelint`
- Add `*.scss` and `*.css` to "side effects" to prevent issues with tree-shaking

With this commit, it is possible to import styles with the same syntax of v10 to prevent a breaking change in webpack based applications

Refs:
- https://webpack.js.org/guides/package-exports/ - 

Close #1184

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (tooling change or documentation change)
- [ ] Refactor (non-breaking change which maintains existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have added new tests for the bug I fixed/the new feature I added.
- [ ] I have modified existing tests for the bug I fixed/the new feature I added.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
