### PR TITLE
Fix various opt-group handling issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Fix regression of `UnhighlightItem` event not firing [#1173](https://github.com/Choices-js/Choices/issues/1173)
 * Fix `clearChoices()` would remove items, and clear the search flag.
 * Fixes for opt-group handling/rendering
+* Fix `removeChoice()` did not properly remove a choice which was part of a group
 
 ### Chore
 * Add e2e tests for "no choices" behavior to match v10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Fix regression "no choices to choose from"/"no results found" notice did not reliably trigger. [#1185](https://github.com/Choices-js/Choices/issues/1185) [#1191](https://github.com/Choices-js/Choices/issues/1191)
 * Fix regression of `UnhighlightItem` event not firing [#1173](https://github.com/Choices-js/Choices/issues/1173)
 * Fix `clearChoices()` would remove items, and clear the search flag.
+* Fixes for opt-group handling/rendering
 
 ### Chore
 * Add e2e tests for "no choices" behavior to match v10

--- a/public/test/select-multiple/index.html
+++ b/public/test/select-multiple/index.html
@@ -914,7 +914,9 @@
             multiple
           >
             <option value="Choice 1">Choice 1</option>
-            <option value="Choice 2">Choice 2</option>
+            <optgroup label="test">
+              <option value="Choice 2">Choice 2</option>
+            </optgroup>
             <option value="Choice 3">Choice 3</option>
           </select>
           <button class="destroy">Destroy</button>

--- a/public/test/select-one/index.html
+++ b/public/test/select-one/index.html
@@ -928,7 +928,7 @@
           </script>
       </div>
 
-      <div data-test-hook="autocomplete">
+        <div data-test-hook="autocomplete">
         <label for="choices-autocomplete">Autocomplete example</label>
         <select
           class="form-control"
@@ -968,7 +968,7 @@
         </script>
       </div>
 
-
+      </div>
     </div>
   </body>
 </html>

--- a/public/test/select-one/index.html
+++ b/public/test/select-one/index.html
@@ -870,7 +870,9 @@
             id="choices-new-destroy-init"
           >
             <option value="Choice 1">Choice 1</option>
-            <option value="Choice 2">Choice 2</option>
+            <optgroup label="test">
+              <option value="Choice 2">Choice 2</option>
+            </optgroup>
             <option value="Choice 3">Choice 3</option>
           </select>
           <button class="destroy">Destroy</button>

--- a/src/scripts/choices.ts
+++ b/src/scripts/choices.ts
@@ -784,16 +784,21 @@ class Choices {
 
       this.clearStore(false);
 
-      choicesFromOptions.forEach((groupOrChoice) => {
-        if ('choices' in groupOrChoice) {
-          return;
-        }
-        const choice = groupOrChoice;
+      const updateChoice = (choice: ChoiceFull): void => {
         if (deselectAll) {
           this._store.dispatch(removeItem(choice));
         } else if (existingItems[choice.value]) {
           choice.selected = true;
         }
+      };
+
+      choicesFromOptions.forEach((groupOrChoice) => {
+        if ('choices' in groupOrChoice) {
+          groupOrChoice.choices.forEach(updateChoice);
+
+          return;
+        }
+        updateChoice(groupOrChoice);
       });
 
       /* @todo only generate add events for the added options instead of all

--- a/src/scripts/choices.ts
+++ b/src/scripts/choices.ts
@@ -996,6 +996,13 @@ class Choices {
         if (config.shouldSort) {
           activeGroups.sort(config.sorter);
         }
+        // render Choices without group first, regardless of sort, otherwise they won't be distinguishable
+        // from the last group
+        renderChoices(
+          activeChoices.filter((choice) => !choice.placeholder && !choice.group),
+          false,
+          undefined,
+        );
 
         activeGroups.forEach((group) => {
           const groupChoices = renderableChoices(group.choices);

--- a/src/scripts/choices.ts
+++ b/src/scripts/choices.ts
@@ -1160,11 +1160,7 @@ class Choices {
     }
   }
 
-  _getChoiceForOutput(choice?: ChoiceFull, keyCode?: number): EventChoice | undefined {
-    if (!choice) {
-      return undefined;
-    }
-
+  _getChoiceForOutput(choice: ChoiceFull, keyCode?: number): EventChoice {
     const group = choice.groupId ? this._store.getGroupById(choice.groupId) : null;
 
     return {

--- a/src/scripts/choices.ts
+++ b/src/scripts/choices.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { activateChoices, addChoice, removeChoice, filterChoices } from './actions/choices';
 import { addGroup } from './actions/groups';
 import { addItem, highlightItem, removeItem } from './actions/items';
@@ -28,7 +27,7 @@ import Store from './store/store';
 import { coerceBool, mapInputToChoice } from './lib/choice-input';
 import { ChoiceFull } from './interfaces/choice-full';
 import { GroupFull } from './interfaces/group-full';
-import { EventType, KeyCodeMap, PassedElementType, PassedElementTypes } from './interfaces';
+import { EventChoiceValueType, EventType, KeyCodeMap, PassedElementType, PassedElementTypes } from './interfaces';
 import { EventChoice } from './interfaces/event-choice';
 import { NoticeType, NoticeTypes, Templates } from './interfaces/templates';
 import { isHtmlInputElement, isHtmlSelectElement } from './lib/html-guard-statements';
@@ -539,13 +538,10 @@ class Choices {
     return this;
   }
 
-  getValue(valueOnly = false): string[] | EventChoice[] | EventChoice | string {
-    const values = this._store.items.reduce<any[]>((selectedItems, item) => {
-      const itemValue = valueOnly ? item.value : this._getChoiceForOutput(item);
-      selectedItems.push(itemValue);
-
-      return selectedItems;
-    }, []);
+  getValue<B extends boolean = false>(valueOnly?: B): EventChoiceValueType<B> | EventChoiceValueType<B>[] {
+    const values = this._store.items.map((item) => {
+      return (valueOnly ? item.value : this._getChoiceForOutput(item)) as EventChoiceValueType<B>;
+    });
 
     return this._isSelectOneElement || this.config.singleModeForMultiSelect ? values[0] : values;
   }

--- a/src/scripts/choices.ts
+++ b/src/scripts/choices.ts
@@ -985,7 +985,7 @@ class Choices {
       if (!this._hasNonChoicePlaceholder && !isSearching && this._isSelectOneElement) {
         // If we have a placeholder choice along with groups
         renderChoices(
-          activeChoices.filter((choice) => choice.placeholder && !choice.groupId),
+          activeChoices.filter((choice) => choice.placeholder && !choice.group),
           false,
           undefined,
         );
@@ -1161,9 +1161,8 @@ class Choices {
     }
   }
 
+  // eslint-disable-next-line class-methods-use-this
   _getChoiceForOutput(choice: ChoiceFull, keyCode?: number): EventChoice {
-    const group = choice.groupId ? this._store.getGroupById(choice.groupId) : null;
-
     return {
       id: choice.id,
       highlighted: choice.highlighted,
@@ -1175,7 +1174,7 @@ class Choices {
       label: choice.label,
       placeholder: choice.placeholder,
       value: choice.value,
-      groupValue: group && group.label ? group.label : undefined,
+      groupValue: choice.group ? choice.group.label : undefined,
       element: choice.element,
       keyCode,
     };
@@ -2128,7 +2127,7 @@ class Choices {
     group.id = this._lastAddedGroupId;
 
     group.choices.forEach((item: ChoiceFull) => {
-      item.groupId = group.id;
+      item.group = group;
       if (group.disabled) {
         item.disabled = true;
       }

--- a/src/scripts/components/wrapped-select.ts
+++ b/src/scripts/components/wrapped-select.ts
@@ -77,7 +77,7 @@ export default class WrappedSelect extends WrappedElement<HTMLSelectElement> {
 
     return {
       id: 0,
-      groupId: 0,
+      group: null,
       score: 0,
       rank: 0,
       value: option.value,

--- a/src/scripts/interfaces/choice-full.ts
+++ b/src/scripts/interfaces/choice-full.ts
@@ -1,5 +1,7 @@
 import { StringUntrusted } from './string-untrusted';
 import { Types } from './types';
+// eslint-disable-next-line import/no-cycle
+import { GroupFull } from './group-full';
 
 /*
   A disabled choice appears in the choice dropdown but cannot be selected
@@ -18,7 +20,7 @@ export interface ChoiceFull {
   disabled: boolean;
   active: boolean;
   elementId?: string;
-  groupId: number;
+  group: GroupFull | null;
   label: StringUntrusted | string;
   placeholder: boolean;
   selected: boolean;

--- a/src/scripts/interfaces/choice-full.ts
+++ b/src/scripts/interfaces/choice-full.ts
@@ -1,7 +1,5 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { StringUntrusted } from './string-untrusted';
-
-export type CustomProperties = Record<string, any> | string;
+import { Types } from './types';
 
 /*
   A disabled choice appears in the choice dropdown but cannot be selected
@@ -16,7 +14,7 @@ export interface ChoiceFull {
   choiceEl?: HTMLElement;
   labelClass?: Array<string>;
   labelDescription?: string;
-  customProperties?: CustomProperties;
+  customProperties?: Types.CustomProperties;
   disabled: boolean;
   active: boolean;
   elementId?: string;

--- a/src/scripts/interfaces/event-choice.ts
+++ b/src/scripts/interfaces/event-choice.ts
@@ -1,5 +1,7 @@
 import { InputChoice } from './input-choice';
 
+export type EventChoiceValueType<B extends boolean> = B extends true ? string : EventChoice;
+
 export interface EventChoice extends InputChoice {
   element?: HTMLOptionElement | HTMLOptGroupElement;
   groupValue?: string;

--- a/src/scripts/interfaces/group-full.ts
+++ b/src/scripts/interfaces/group-full.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import { ChoiceFull } from './choice-full';
 
 export interface GroupFull {

--- a/src/scripts/interfaces/group-full.ts
+++ b/src/scripts/interfaces/group-full.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line import/no-cycle
 import { ChoiceFull } from './choice-full';
 
 export interface GroupFull {

--- a/src/scripts/interfaces/input-choice.ts
+++ b/src/scripts/interfaces/input-choice.ts
@@ -1,17 +1,17 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import { StringUntrusted } from './string-untrusted';
+import { Types } from './types';
 
 export interface InputChoice {
   id?: number;
   highlighted?: boolean;
   labelClass?: string | Array<string>;
   labelDescription?: string;
-  customProperties?: Record<string, any> | string;
+  customProperties?: Types.CustomProperties;
   disabled?: boolean;
   active?: boolean;
   label: StringUntrusted | string;
   placeholder?: boolean;
   selected?: boolean;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   value: any;
 }

--- a/src/scripts/interfaces/input-group.ts
+++ b/src/scripts/interfaces/input-group.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import { InputChoice } from './input-choice';
 import { StringUntrusted } from './string-untrusted';
 

--- a/src/scripts/interfaces/types.ts
+++ b/src/scripts/interfaces/types.ts
@@ -16,4 +16,6 @@ export namespace Types {
     label?: StringUntrusted | string;
   }
   export type ValueOf<T extends object> = T[keyof T];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  export type CustomProperties = Record<string, any> | string;
 }

--- a/src/scripts/lib/choice-input.ts
+++ b/src/scripts/lib/choice-input.ts
@@ -64,7 +64,7 @@ export const mapInputToChoice = <T extends string | InputChoice | InputGroup>(
 
   const result: ChoiceFull = {
     id: 0, // actual ID will be assigned during _addChoice
-    groupId: 0, // actual ID will be assigned during _addGroup but before _addChoice
+    group: null, // actual group will be assigned during _addGroup but before _addChoice
     score: 0, // used in search
     rank: 0, // used in search, stable sort order
     value: choice.value,

--- a/src/scripts/lib/utils.ts
+++ b/src/scripts/lib/utils.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import { EventTypes } from '../interfaces/event-type';
 import { StringUntrusted } from '../interfaces/string-untrusted';
 import { StringPreEscaped } from '../interfaces/string-pre-escaped';
@@ -179,6 +177,7 @@ export const cloneObject = <T>(obj: T): T => (obj !== undefined ? JSON.parse(JSO
 /**
  * Returns an array of keys present on the first but missing on the second object
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const diff = (a: Record<string, any>, b: Record<string, any>): string[] => {
   const aKeys = Object.keys(a).sort();
   const bKeys = Object.keys(b).sort();

--- a/src/scripts/reducers/choices.ts
+++ b/src/scripts/reducers/choices.ts
@@ -22,6 +22,9 @@ export default function choices(s: StateType, action: ActionTypes, context?: Opt
     case ActionType.REMOVE_CHOICE: {
       action.choice.choiceEl = undefined;
 
+      if (action.choice.group) {
+        action.choice.group.choices = action.choice.group.choices.filter((obj) => obj.id !== action.choice.id);
+      }
       state = state.filter((obj) => obj.id !== action.choice.id);
       break;
     }

--- a/src/scripts/reducers/items.ts
+++ b/src/scripts/reducers/items.ts
@@ -54,8 +54,8 @@ export default function items(s: StateType, action: ActionTypes, context?: Optio
     }
 
     case ActionType.REMOVE_CHOICE: {
-      state = state.filter((item) => item.id !== action.choice.id);
       removeItem(action.choice);
+      state = state.filter((item) => item.id !== action.choice.id);
       break;
     }
 

--- a/src/scripts/templates.ts
+++ b/src/scripts/templates.ts
@@ -268,7 +268,6 @@ const templates: TemplatesInterface = {
       label = escapeForTemplate(allowHTML, label);
       label += ` (${groupName})`;
       label = { trusted: label };
-      div.dataset.groupId = `${choice.groupId}`;
     }
 
     let describedBy: HTMLElement = div;
@@ -307,6 +306,9 @@ const templates: TemplatesInterface = {
     div.dataset.value = rawValue;
     if (selectText) {
       div.dataset.selectText = selectText;
+    }
+    if (choice.groupId) {
+      div.dataset.groupId = `${choice.groupId}`;
     }
 
     assignCustomProperties(div, choice, false);

--- a/src/scripts/templates.ts
+++ b/src/scripts/templates.ts
@@ -299,7 +299,7 @@ const templates: TemplatesInterface = {
       addClassesToElement(div, placeholder);
     }
 
-    div.setAttribute('role', choice.groupId ? 'treeitem' : 'option');
+    div.setAttribute('role', choice.group ? 'treeitem' : 'option');
 
     div.dataset.choice = '';
     div.dataset.id = choice.id as unknown as string;
@@ -307,8 +307,8 @@ const templates: TemplatesInterface = {
     if (selectText) {
       div.dataset.selectText = selectText;
     }
-    if (choice.groupId) {
-      div.dataset.groupId = `${choice.groupId}`;
+    if (choice.group) {
+      div.dataset.groupId = `${choice.group.id}`;
     }
 
     assignCustomProperties(div, choice, false);

--- a/test-e2e/tests/select-multiple.spec.ts
+++ b/test-e2e/tests/select-multiple.spec.ts
@@ -961,7 +961,8 @@ describe(`Choices - select multiple`, () => {
         await suite.group.locator('.destroy').click({ force: true });
         await suite.advanceClock();
 
-        await expect(suite.group.locator('select > option')).toHaveCount(3);
+        await expect(suite.group.locator('select > optgroup > option')).toHaveCount(1);
+        await expect(suite.group.locator('select > option')).toHaveCount(2);
 
         await suite.group.locator('.init').click({ force: true });
         await suite.advanceClock();

--- a/test-e2e/tests/select-multiple.spec.ts
+++ b/test-e2e/tests/select-multiple.spec.ts
@@ -683,9 +683,10 @@ describe(`Choices - select multiple`, () => {
           await suite.startWithClick();
 
           await expect(suite.dropdown.locator('.choices__group[data-group]')).toHaveCount(1);
-          expect(
-            await suite.selectableChoices.filter({ hasNot: page.locator('[data-group-id]') }).count(),
-          ).toBeGreaterThan(0);
+          expect(await suite.dropdown.locator('.choices__item--choice[data-group-id]').count()).toEqual(1);
+          expect(await suite.dropdown.locator('.choices__item--choice:not([data-group-id])').count()).toBeGreaterThan(
+            1,
+          );
         });
       });
     });

--- a/test-e2e/tests/select-one.spec.ts
+++ b/test-e2e/tests/select-one.spec.ts
@@ -528,9 +528,10 @@ describe(`Choices - select one`, () => {
           await suite.startWithClick();
 
           await expect(suite.dropdown.locator('.choices__group[data-group]')).toHaveCount(1);
-          expect(
-            await suite.selectableChoices.filter({ hasNot: page.locator('[data-group-id]') }).count(),
-          ).toBeGreaterThan(0);
+          expect(await suite.dropdown.locator('.choices__item--choice[data-group-id]').count()).toEqual(1);
+          expect(await suite.dropdown.locator('.choices__item--choice:not([data-group-id])').count()).toBeGreaterThan(
+            1,
+          );
         });
       });
     });

--- a/test-e2e/tests/select-one.spec.ts
+++ b/test-e2e/tests/select-one.spec.ts
@@ -835,7 +835,8 @@ describe(`Choices - select one`, () => {
         await suite.group.locator('.destroy').click({ force: true });
         await suite.advanceClock();
 
-        await expect(suite.group.locator('select > option')).toHaveCount(3);
+        await expect(suite.group.locator('select > optgroup > option')).toHaveCount(1);
+        await expect(suite.group.locator('select > option')).toHaveCount(2);
 
         await suite.group.locator('.init').click({ force: true });
         await suite.advanceClock();

--- a/test/scripts/choices.test.ts
+++ b/test/scripts/choices.test.ts
@@ -756,7 +756,7 @@ describe('choices', () => {
       let itemsStub;
       const groupIdValue = 'Test';
       const item: ChoiceFull = {
-        groupId: 1,
+        group: null,
         highlighted: false,
         active: false,
         disabled: false,
@@ -827,9 +827,9 @@ describe('choices', () => {
           });
         });
 
-        describe('item with negative groupId', () => {
+        describe('item with no group', () => {
           beforeEach(() => {
-            item.groupId = 0;
+            item.group = null;
             output = instance.highlightItem(item);
           });
 
@@ -845,9 +845,17 @@ describe('choices', () => {
           });
         });
 
-        describe('item without groupId', () => {
+        describe('item with group', () => {
           beforeEach(() => {
-            item.groupId = 4321;
+            item.group = {
+              active: true,
+              choices: [],
+              disabled: false,
+              element: undefined,
+              groupEl: undefined,
+              id: 4321,
+              label: groupIdValue,
+            };
             output = instance.highlightItem(item);
           });
 
@@ -887,7 +895,7 @@ describe('choices', () => {
       let storeGetGroupByIdStub;
       const groupIdValue = 'Test';
       const item: ChoiceFull = {
-        groupId: 1,
+        group: null,
         highlighted: true,
         active: false,
         disabled: false,
@@ -958,9 +966,9 @@ describe('choices', () => {
           });
         });
 
-        describe('item with negative groupId', () => {
+        describe('item without group', () => {
           beforeEach(() => {
-            item.groupId = 0;
+            item.group = null;
             output = instance.unhighlightItem(item);
           });
 
@@ -975,9 +983,17 @@ describe('choices', () => {
           });
         });
 
-        describe('item without groupId', () => {
+        describe('item with group', () => {
           beforeEach(() => {
-            item.groupId = 4321;
+            item.group = {
+              active: true,
+              choices: [],
+              disabled: false,
+              element: undefined,
+              groupEl: undefined,
+              id: 4321,
+              label: groupIdValue,
+            };
             output = instance.unhighlightItem(item);
           });
 
@@ -1020,7 +1036,7 @@ describe('choices', () => {
           highlighted: false,
           disabled: false,
           active: false,
-          groupId: 0,
+          group: null,
           label: '',
           placeholder: false,
           selected: false,
@@ -1033,7 +1049,7 @@ describe('choices', () => {
           highlighted: false,
           disabled: false,
           active: false,
-          groupId: 0,
+          group: null,
           label: '',
           placeholder: false,
           selected: false,
@@ -1087,7 +1103,7 @@ describe('choices', () => {
           highlighted: true,
           disabled: false,
           active: false,
-          groupId: 0,
+          group: null,
           label: '',
           placeholder: false,
           selected: false,
@@ -1100,7 +1116,7 @@ describe('choices', () => {
           highlighted: true,
           disabled: false,
           active: false,
-          groupId: 0,
+          group: null,
           label: '',
           placeholder: false,
           selected: false,
@@ -2213,7 +2229,7 @@ describe('choices', () => {
           id: 1111,
           value: 'test value',
           label: 'test label',
-          groupId: 3333,
+          group: null,
           customProperties: {},
           score: 0,
           rank: 0,
@@ -2253,7 +2269,7 @@ describe('choices', () => {
           const itemWithGroup = {
             ...item,
             value: 'testing',
-            groupId: group.id,
+            group,
           };
 
           beforeEach(() => {

--- a/test/scripts/reducers/choices.test.ts
+++ b/test/scripts/reducers/choices.test.ts
@@ -73,7 +73,7 @@ describe('reducers/choices', () => {
         {
           id: 1,
           elementId: 'choices-test-1',
-          groupId: 0,
+          group: null,
           value: 'Choice 1',
           label: 'Choice 1',
           disabled: false,
@@ -88,7 +88,7 @@ describe('reducers/choices', () => {
         {
           id: 2,
           elementId: 'choices-test-2',
-          groupId: 0,
+          group: null,
           value: 'Choice 2',
           label: 'Choice 2',
           disabled: false,

--- a/test/scripts/reducers/choices.test.ts
+++ b/test/scripts/reducers/choices.test.ts
@@ -14,7 +14,7 @@ describe('reducers/choices', () => {
         label: 'test',
         id: 1,
         elementId: '1',
-        groupId: 1,
+        group: null,
         active: false,
         disabled: false,
         placeholder: true,

--- a/test/scripts/reducers/items.test.ts
+++ b/test/scripts/reducers/items.test.ts
@@ -79,7 +79,7 @@ describe('reducers/items', () => {
       state = [
         {
           id: 1,
-          groupId: 0,
+          group: null,
           score: 0,
           rank: 0,
           value: 'Item one',
@@ -93,7 +93,7 @@ describe('reducers/items', () => {
         },
         {
           id: 2,
-          groupId: 0,
+          group: null,
           score: 0,
           rank: 0,
           value: 'Item one',

--- a/test/scripts/reducers/items.test.ts
+++ b/test/scripts/reducers/items.test.ts
@@ -13,7 +13,7 @@ describe('reducers/items', () => {
         value: 'Item one',
         label: 'Item one',
         id: 1234,
-        groupId: 1,
+        group: null,
         score: 0,
         rank: 0,
         customProperties: {

--- a/test/scripts/store/store.test.ts
+++ b/test/scripts/store/store.test.ts
@@ -14,7 +14,7 @@ function shimStore() {
 
 describe('reducers/store', () => {
   let instance: Store<Options>;
-  let subscribeStub: sinon.SinonStub<[listener: StoreListener], void>;
+  let subscribeStub: sinon.SinonStub<[listener: StoreListener], Store<Options>>;
   let dispatchStub: sinon.SinonStub<[action: AnyAction], void>;
   let getStateStub: sinon.SinonStub<any[], State>;
   let emptyState: State;

--- a/test/scripts/store/store.test.ts
+++ b/test/scripts/store/store.test.ts
@@ -30,7 +30,7 @@ describe('reducers/store', () => {
       items: [
         {
           id: 1,
-          groupId: 0,
+          group: null,
           value: 'Item one',
           label: 'Item one',
           active: false,
@@ -44,7 +44,7 @@ describe('reducers/store', () => {
         },
         {
           id: 2,
-          groupId: 0,
+          group: null,
           value: 'Item two',
           label: 'Item two',
           active: true,
@@ -58,7 +58,7 @@ describe('reducers/store', () => {
         },
         {
           id: 3,
-          groupId: 0,
+          group: null,
           value: 'Item three',
           label: 'Item three',
           active: true,
@@ -75,7 +75,7 @@ describe('reducers/store', () => {
         {
           id: 1,
           elementId: 'choices-test-1',
-          groupId: 0,
+          group: null,
           value: 'Choice 1',
           label: 'Choice 1',
           disabled: false,
@@ -90,7 +90,7 @@ describe('reducers/store', () => {
         {
           id: 2,
           elementId: 'choices-test-2',
-          groupId: 0,
+          group: null,
           value: 'Choice 2',
           label: 'Choice 2',
           disabled: false,

--- a/test/scripts/templates.test.ts
+++ b/test/scripts/templates.test.ts
@@ -406,7 +406,7 @@ describe('templates', () => {
     beforeEach(() => {
       data = {
         id: 1,
-        groupId: 0,
+        group: null,
         disabled: false,
         elementId: 'test',
         label: 'test',
@@ -541,7 +541,7 @@ describe('templates', () => {
       beforeEach(() => {
         data = {
           ...data,
-          groupId: 1,
+          group: { id: 1, label: 'test' },
         };
       });
 


### PR DESCRIPTION
- Fix refresh() did not work properly with opt-groups
- Fix group-id was not added to choices outside of search
- Fix opt-group e2e tests false positive
- Fix removing a choice didn't work properly when it was part of a group
- Fix regression of choices without groups where not rendered when groups where present