### PR TITLE
Fix search was not stopped when leaving focus with `esc` key

### DIFF
--- a/src/scripts/choices.ts
+++ b/src/scripts/choices.ts
@@ -1762,6 +1762,7 @@ class Choices {
     if (hasActiveDropdown) {
       event.stopPropagation();
       this.hideDropdown(true);
+      this.refresh(false, false, true);
       this.containerOuter.element.focus();
     }
   }

--- a/src/scripts/choices.ts
+++ b/src/scripts/choices.ts
@@ -1762,7 +1762,7 @@ class Choices {
     if (hasActiveDropdown) {
       event.stopPropagation();
       this.hideDropdown(true);
-      this.refresh(false, false, true);
+      this._stopSearch();
       this.containerOuter.element.focus();
     }
   }


### PR DESCRIPTION
## Description

This PR aims to refresh the list when clicking escape if a search is active.
There currently is a bug where you'd search for something and want to focus out of it when pressing escape - when this happens, you'll lose focus completely and there will not be any items left with a blank search input.

This can be reproduced in the current demo when searching for something and pressing escape - the choices will be gone and only appear again if you type something and then delete it again:
https://choices-js.github.io/Choices/

-> See Screenshot below

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate)

![image](https://github.com/user-attachments/assets/f26e0274-882f-4370-8636-61b87718f0a3)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (tooling change or documentation change)
- [ ] Refactor (non-breaking change which maintains existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have added new tests for the bug I fixed/the new feature I added.
- [ ] I have modified existing tests for the bug I fixed/the new feature I added.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
