### PR TITLE
Fix `shift` key handling when navigating with `tab`

### DIFF
--- a/src/scripts/choices.ts
+++ b/src/scripts/choices.ts
@@ -1606,15 +1606,15 @@ class Choices {
       event.key === 'Unidentified';
 
     /*
-      We do not show the dropdown if the keycode was tab or esc
-      as these one are used to focusOut of e.g. select choices.
+      We do not show the dropdown if focusing out with esc or navigating through input fields.
       An activated search can still be opened with any other key.
      */
     if (
       !this._isTextElement &&
       !hasActiveDropdown &&
       keyCode !== KeyCodeMap.ESC_KEY &&
-      keyCode !== KeyCodeMap.TAB_KEY
+      keyCode !== KeyCodeMap.TAB_KEY &&
+      keyCode !== KeyCodeMap.SHIFT_KEY
     ) {
       this.showDropdown();
 

--- a/src/scripts/interfaces/keycode-map.ts
+++ b/src/scripts/interfaces/keycode-map.ts
@@ -1,5 +1,6 @@
 export const KeyCodeMap = {
   TAB_KEY: 9,
+  SHIFT_KEY: 16,
   BACK_KEY: 46,
   DELETE_KEY: 8,
   ENTER_KEY: 13,


### PR DESCRIPTION
## Description

Continuation of #1239

If a search exists within the field, the first shift press would still open the navigation when trying to navigate back using `shift` + `tab`.

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (tooling change or documentation change)
- [ ] Refactor (non-breaking change which maintains existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have added new tests for the bug I fixed/the new feature I added.
- [ ] I have modified existing tests for the bug I fixed/the new feature I added.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
