### PR TITLE
Improve cjs compatibility by removing pinned "module" type in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "choices.js",
   "version": "11.0.3",
   "description": "A vanilla JS customisable text input/select box plugin",
-  "type": "module",
   "main": "./public/assets/scripts/choices.js",
   "module": "./public/assets/scripts/choices.mjs",
   "unpkg": "./public/assets/scripts/choices.js",


### PR DESCRIPTION
## Description

Fixes https://github.com/Choices-js/Choices/issues/1250

The `package.json` file contains both `module` and `main` entry points. Therefore, it is unnecessary to pin the `module` type for compatibility reasons. This PR removes the module type to ensure compatibility with CommonJS.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (tooling change or documentation change)
- [ ] Refactor (non-breaking change which maintains existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have added new tests for the bug I fixed/the new feature I added.
- [ ] I have modified existing tests for the bug I fixed/the new feature I added.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
