### PR TITLE
Do not preventDefault on item to support dragging

### DIFF
--- a/src/scripts/choices.ts
+++ b/src/scripts/choices.ts
@@ -1886,18 +1886,24 @@ class Choices {
       return;
     }
 
+    let preventDefault = true;
+
     const item = target.closest('[data-button],[data-item],[data-choice]');
     if (item instanceof HTMLElement) {
       if ('button' in item.dataset) {
         this._handleButtonAction(item);
       } else if ('item' in item.dataset) {
         this._handleItemAction(item, event.shiftKey);
+        // don't prevent default to support dragging
+        preventDefault = false;
       } else if ('choice' in item.dataset) {
         this._handleChoiceAction(item);
       }
     }
 
-    event.preventDefault();
+    if (preventDefault) {
+      event.preventDefault();
+    }
   }
 
   /**


### PR DESCRIPTION
## Description

A very long-standing feature request was to add drag-and-drop support for reordering the items. The previous maintainers wanted to keep Choices as lean as possible. I fully understand that. 

I wanted to use the [Sortable](https://github.com/SortableJS/Sortable) to accomplish this. I found that using `preventDefault` on `mousedown` events was blocking dragging when I tried to integrate the two libraries. 

I did not want to simply turn off `preventDefault` for all `mousedown` events. However, after testing, I could not see why it was required when clicking on an item. So I added a variable that makes it very apparent what is going on. 

https://github.com/Choices-js/Choices/issues/417
https://github.com/Choices-js/Choices/issues/1094
https://github.com/Choices-js/Choices/issues/920


## Screenshots (if appropriate)

![CleanShot 2025-02-18 at 11 24 06](https://github.com/user-attachments/assets/b1bb566e-7b40-4288-9af8-5f17392b1ffb)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (tooling change or documentation change)
- [x] Refactor (non-breaking change which maintains existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have added new tests for the bug I fixed/the new feature I added.
- [ ] I have modified existing tests for the bug I fixed/the new feature I added.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Example Sortable Integration

Here is how I integrated Sortable with Choices. This is just a portion of my class so that you can see how it's done. 

```js
constructor(container, options) {
	this.choices = new Choices(this.input, {
		callbackOnInit : this.initSortable.bind(this),
	});
}

initSortable() {
	const list = this.container.querySelector('.choices__list');

	this.sortable = new Sortable(list, {
		animation  : 150,
		draggable  : ".choices__item",
		ghostClass : 'drag-ghost',
		onEnd      : this.syncChoices.bind(this)
	});
}

syncChoices(event) {
	const oldIndex = event.oldIndex;
	const newIndex = event.newIndex;

	if (oldIndex === newIndex) {
		return;
	}

	const select = this.container.querySelector('select.choices__input');
	const options = Array.from(select.options);
	const movedOption = options.splice(oldIndex, 1)[0];
	options.splice(newIndex, 0, movedOption);

	select.innerHTML = '';
	options.forEach(option => select.appendChild(option));
}
```