### PR TITLE
Remove `role="textbox"` from search input, per a11y practices. #941

### DIFF
--- a/public/assets/scripts/choices.js
+++ b/public/assets/scripts/choices.js
@@ -3247,7 +3247,6 @@
             inp.autocomplete = 'off';
             inp.autocapitalize = 'off';
             inp.spellcheck = false;
-            inp.setAttribute('role', 'textbox');
             inp.setAttribute('aria-autocomplete', 'list');
             if (placeholderValue) {
                 inp.setAttribute('aria-label', placeholderValue);

--- a/public/assets/scripts/choices.mjs
+++ b/public/assets/scripts/choices.mjs
@@ -3241,7 +3241,6 @@ var templates = {
         inp.autocomplete = 'off';
         inp.autocapitalize = 'off';
         inp.spellcheck = false;
-        inp.setAttribute('role', 'textbox');
         inp.setAttribute('aria-autocomplete', 'list');
         if (placeholderValue) {
             inp.setAttribute('aria-label', placeholderValue);

--- a/public/assets/scripts/choices.search-basic.js
+++ b/public/assets/scripts/choices.search-basic.js
@@ -2765,7 +2765,6 @@
             inp.autocomplete = 'off';
             inp.autocapitalize = 'off';
             inp.spellcheck = false;
-            inp.setAttribute('role', 'textbox');
             inp.setAttribute('aria-autocomplete', 'list');
             if (placeholderValue) {
                 inp.setAttribute('aria-label', placeholderValue);

--- a/public/assets/scripts/choices.search-basic.mjs
+++ b/public/assets/scripts/choices.search-basic.mjs
@@ -2759,7 +2759,6 @@ var templates = {
         inp.autocomplete = 'off';
         inp.autocapitalize = 'off';
         inp.spellcheck = false;
-        inp.setAttribute('role', 'textbox');
         inp.setAttribute('aria-autocomplete', 'list');
         if (placeholderValue) {
             inp.setAttribute('aria-label', placeholderValue);

--- a/public/assets/scripts/choices.search-prefix.js
+++ b/public/assets/scripts/choices.search-prefix.js
@@ -1607,7 +1607,6 @@
             inp.autocomplete = 'off';
             inp.autocapitalize = 'off';
             inp.spellcheck = false;
-            inp.setAttribute('role', 'textbox');
             inp.setAttribute('aria-autocomplete', 'list');
             if (placeholderValue) {
                 inp.setAttribute('aria-label', placeholderValue);

--- a/public/assets/scripts/choices.search-prefix.mjs
+++ b/public/assets/scripts/choices.search-prefix.mjs
@@ -1601,7 +1601,6 @@ var templates = {
         inp.autocomplete = 'off';
         inp.autocapitalize = 'off';
         inp.spellcheck = false;
-        inp.setAttribute('role', 'textbox');
         inp.setAttribute('aria-autocomplete', 'list');
         if (placeholderValue) {
             inp.setAttribute('aria-label', placeholderValue);

--- a/src/scripts/templates.ts
+++ b/src/scripts/templates.ts
@@ -337,7 +337,6 @@ const templates: TemplatesInterface = {
     inp.autocapitalize = 'off';
     inp.spellcheck = false;
 
-    inp.setAttribute('role', 'textbox');
     inp.setAttribute('aria-autocomplete', 'list');
     if (placeholderValue) {
       inp.setAttribute('aria-label', placeholderValue);

--- a/test/scripts/templates.test.ts
+++ b/test/scripts/templates.test.ts
@@ -588,7 +588,6 @@ describe('templates', () => {
           type="search"
           class="${getClassNames(inputOptions.classNames.input).join(' ')} ${getClassNames(inputOptions.classNames.inputCloned).join(' ')}"
           autocomplete="off"
-          role="textbox"
           aria-autocomplete="list"
           aria-label="test placeholder"
         >


### PR DESCRIPTION
## Description
A typical Choices dropdown will add the attribute role="textbox" to the search textbox:
`<input type="search" class="choices__input" role="textbox" >`

According to a11y best practice, it's recommended to not add the role="textbox" to an text or search element . Rather, screen readers and other assistive technologies already infer that it's a textbox from the element itself.


https://www.w3.org/TR/wai-aria-1.2/#textbox
> The intended use is for languages that do not have a text input [element](https://www.w3.org/TR/wai-aria-1.2/#dfn-element), or cases in which an element with different [semantics](https://www.w3.org/TR/wai-aria-1.2/#dfn-semantics) is repurposed as a text field.

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/textbox_role
> The textbox role is used to identify an element that allows the input of free-form text. Whenever possible, rather than using this role, use an [<input>](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input) element with [type="text"](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/text), for single-line input, or a [<textarea>](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea) element for multi-line input.

In other words, both sources imply this should only be used on non-input elements.  

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (tooling change or documentation change)
- [ ] Refactor (non-breaking change which maintains existing functionality)
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

This PR removes setting a role="textbox" to the **input type="search"** element of a choices dropdown.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] I have added new tests for the bug I fixed/the new feature I added.
- [X] I have modified existing tests for the bug I fixed/the new feature I added.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
