### PR TITLE
Disable `searchResultLimit` by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ import "choices.js/public/assets/styles/choices.css";
     searchEnabled: true,
     searchChoices: true,
     searchFloor: 1,
-    searchResultLimit: 4,
+    searchResultLimit: -1,
     searchFields: ['label', 'value'],
     position: 'auto',
     resetScrollPosition: true,
@@ -496,9 +496,9 @@ Pass an array of objects:
 
 **Usage:** The minimum length a search value should be before choices are searched.
 
-### searchResultLimit: 4,
+### searchResultLimit,
 
-**Type:** `Number` **Default:** `4`
+**Type:** `Number` **Default:** `-1`
 
 **Input types affected:** `select-one`, `select-multiple`
 

--- a/src/scripts/defaults.ts
+++ b/src/scripts/defaults.ts
@@ -57,7 +57,7 @@ export const DEFAULT_CONFIG: Options = {
   searchEnabled: true,
   searchChoices: true,
   searchFloor: 1,
-  searchResultLimit: 4,
+  searchResultLimit: -1,
   searchFields: ['label', 'value'],
   position: 'auto',
   resetScrollPosition: true,


### PR DESCRIPTION
## Description

I got confused when using some of the default settings of Choices.js plus `searchEnabled: true` that I could not find entries via the search in larger selects, unless I typed in more letters of the entry that I was looking for. So for example if I typed the letter _a_, it did not show all entries with that letter.

The reason for this is that the default `searchResultLimit` is set to _4_:

https://github.com/Choices-js/Choices/blob/8c0c11e26f2d1446263c20f85e0c437c6e37f74e/src/scripts/defaults.ts#L60

However, this does not make much sense to me as by default the `renderChoiceLimit` is set to `-1`

https://github.com/Choices-js/Choices/blob/8c0c11e26f2d1446263c20f85e0c437c6e37f74e/src/scripts/defaults.ts#L41

i.e. Choices.js will always show all entries of the `<select>`. But when searching for something - which would already filter down the entries to less or equal than _all_ - the result is suddenly limited to 4.

So I think it makes sense that the default for `searchResultLimit` should always be the same as `renderChoiceLimit`.

Generally I am not sure what the use-case is for having a `searchResultLimit` that is lower than the `renderChoiceLimit`.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (tooling change or documentation change)
- [ ] Refactor (non-breaking change which maintains existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

I think this constitutes a breaking change because if someone configured a `renderChoiceLimit` because they have a lot of `<option>`s and they did not set a `searchResultLimit`, they would suddenly potentially get more search results than their `renderChoiceLimit`.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have added new tests for the bug I fixed/the new feature I added.
- [ ] I have modified existing tests for the bug I fixed/the new feature I added.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
