### PR TITLE
docs: update versioned URLs to current major

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,9 @@ yarn add choices.js
 
 From a [CDN](https://www.jsdelivr.com/package/npm/choices.js):
 
-**Note:** There is sometimes a delay before the latest version of Choices is reflected on the CDN.
-
+**Notes:** 
+* There is sometimes a delay before the latest version of Choices is reflected on the CDN.
+* Examples below pin a version (v11.0.6). Check [latest release](https://www.jsdelivr.com/package/npm/choices.js) and update v11.0.6 to the latest tag before using.
 ```html
 <!-- Include base CSS (optional) -->
 <link

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ From a [CDN](https://www.jsdelivr.com/package/npm/choices.js):
 <!-- Or versioned -->
 <link
   rel="stylesheet"
-  href="https://cdn.jsdelivr.net/npm/choices.js@9.0.1/public/assets/styles/base.min.css"
+  href="https://cdn.jsdelivr.net/npm/choices.js@11.0.6/public/assets/styles/base.min.css"
 />
 
 <!-- Include Choices CSS -->
@@ -86,13 +86,13 @@ From a [CDN](https://www.jsdelivr.com/package/npm/choices.js):
 <!-- Or versioned -->
 <link
   rel="stylesheet"
-  href="https://cdn.jsdelivr.net/npm/choices.js@9.0.1/public/assets/styles/choices.min.css"
+  href="https://cdn.jsdelivr.net/npm/choices.js@11.0.6/public/assets/styles/choices.min.css"
 />
 
 <!-- Include Choices JavaScript (latest) -->
 <script src="https://cdn.jsdelivr.net/npm/choices.js/public/assets/scripts/choices.min.js"></script>
 <!-- Or versioned -->
-<script src="https://cdn.jsdelivr.net/npm/choices.js@9.0.1/public/assets/scripts/choices.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/choices.js@11.0.6/public/assets/scripts/choices.min.js"></script>
 ```
 
 Or include Choices directly:


### PR DESCRIPTION
## Description

Hi,

The README referenced versioned URLs two major releases behind. Readers copying the examples end up installing an old version, leading to behavior that doesn’t match the current docs (ask me how I know 🫠)

This PR updates all versioned URLs to the current major.

Docs-only change; no code impact.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (tooling change or documentation change)
- [ ] Refactor (non-breaking change which maintains existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist


- [x] My code follows the code style of this project.
- [x] I have added new tests for the bug I fixed/the new feature I added.
- [x] I have modified existing tests for the bug I fixed/the new feature I added.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
